### PR TITLE
Clean up which old prompts are shown.

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,8 +228,8 @@ app.get(
     const { class_id } = req.params;
     db.allPromptsForClass(class_id, (err, prompts) => {
       const open = openPrompts(prompts);
-      const unique = uniquePrompts(prompts);
-      dbRender(res, err, 'prompts.njk', { ...req.params, open, unique });
+      const old = oldPrompts(prompts);
+      dbRender(res, err, 'prompts.njk', { ...req.params, open, old });
     });
   }),
 );
@@ -263,16 +263,16 @@ app.get(
 
 const openPrompts = (prompts) => prompts.filter((p) => p.closed_at === null);
 
-const uniquePrompts = (prompts) => {
+const oldPrompts = (prompts) => {
   const seen = {};
-  const unique = [];
+  const old = [];
   prompts.forEach((p) => {
     if (!seen[p.text]) {
       seen[p.text] = true;
-      unique.push(p);
+      if (p.closed_at !== null) old.push(p);
     }
   });
-  return unique;
+  return old;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/modules/storage.js
+++ b/modules/storage.js
@@ -500,7 +500,13 @@ class DB {
   }
 
   allPromptsForClass(classId, callback) {
-    this.db.all('select * from prompts where class_id = ?', classId, callback);
+    const q = `
+      select * from prompts where
+        class_id = ?
+        and (closed_at is null or
+             prompt_id in (select prompt_id from journal where prompt_id is not null))
+    `;
+    this.db.all(q, classId, callback);
   }
 
   openPromptsForStudent(email, classId, callback) {

--- a/views/prompts.njk
+++ b/views/prompts.njk
@@ -38,13 +38,13 @@
 
 {% endif %}
 
-<h2>All prompts</h2>
+{% if old.length > 0 %}
 
-{% if unique.length > 0 %}
+<h2>Old prompts</h2>
 
 <table>
   <tbody>
-    {% for p in unique %}
+    {% for p in old %}
     <tr>
       <td>{{ p.text | md | safe}}</td>
       <td class="actions">
@@ -54,10 +54,6 @@
     {% endfor %}
   </tbody>
 </table>
-
-{% else %}
-
-<p>No prompts yet.</p>
 
 {% endif %}
 


### PR DESCRIPTION
Change the set of prompts we show on the teacher-only prompts page to only show old prompts if they are not currently open and if they got responses. Basically hide prompts that were made and closed without ever really being used since they were probably mistakes and just clutter things up.